### PR TITLE
Lets user specify own paths & adds 00X numbering

### DIFF
--- a/renumber_julie_midi_files.ipynb
+++ b/renumber_julie_midi_files.ipynb
@@ -2,17 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "import os\n",
-    "import shutil"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [
@@ -40,7 +29,21 @@
     }
    ],
    "source": [
-    "df = pd.read_excel('log_annotated_data.xlsx')\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# INPUTS\n",
+    "root_src_directory = r'\\\\?\\\\' + os.path.abspath(r\"C:\\Users\\julie\\Documents\\OMSA\\deep_learning\\final_project\\DoReMi_v1\\DoReMi_v1\\Dorico_project\\puckett_midi_needs_cleaning\")\n",
+    "root_dst_directory = r'\\\\?\\\\' + os.path.abspath(r\"C:\\Users\\julie\\Documents\\OMSA\\deep_learning\\final_project\\DoReMi_v1\\DoReMi_v1\\Dorico_project\\puckett_midi_input_final\")\n",
+    "log_file = os.path.join(root_src_directory, 'puckett_log_annotated_data.xlsx')\n",
+    "\n",
+    "# Read log file indicating whether need to add 1 to file suffix or not\n",
+    "df = pd.read_excel(log_file)\n",
+    "\n",
+    "# Create directory for this teammate's MIDI files to go in\n",
+    "if not os.path.exists(root_dst_directory):\n",
+    "    os.makedirs(root_dst_directory)\n",
     "\n",
     "# For each piece...\n",
     "for i, row in df.iterrows():\n",
@@ -49,23 +52,21 @@
     "    print(piece)\n",
     "\n",
     "    # Directory names (r'\\\\?\\\\' allows code to handle cases with path length too long for operating system)\n",
-    "    src_directory = r'\\\\?\\\\' + os.path.abspath(f'Flows from {piece}')\n",
-    "    dst_directory = r'\\\\?\\\\' + os.path.abspath(f'Flows from {piece}_renumbered')\n",
+    "    src_directory = os.path.join(root_src_directory, f'Flows from {piece}')\n",
+    "    dst_directory = os.path.join(root_dst_directory, piece)\n",
     "\n",
     "    # For each file (MIDI) in this piece's directory...\n",
     "    for root, dirs, files in os.walk(src_directory):\n",
     "        for src_name in files:\n",
-    "            src_file = os.path.join(root, src_name)\n",
+    "            src_file = os.path.join(root, src_name) # path to this MIDI file\n",
     "            \n",
-    "            # Set name of copied file\n",
-    "            if row['add 1?'] == 1: # If excel file has 'add 1?' = TRUE (1), add 1 to its number\n",
-    "                dst_final_seg = src_name.rsplit(' ', 1)[-1][:-4]\n",
-    "                if dst_final_seg.isdigit(): # Base case: original file ends in a digit\n",
-    "                    dst_name = src_name[:src_name.rfind(' ')] + ' ' + str(int(dst_final_seg) + 1) + '.mid'\n",
-    "                else: # Edge case: original file has no number at the end (\"file 0\")\n",
-    "                    dst_name = src_name[:len(src_name)-4] + ' 1.mid'\n",
-    "            else: # If excel file has 'add 1?' == FALSE, no addition needed. Just copy the file (with a shortened name).\n",
-    "                dst_name = src_name\n",
+    "            dst_final_seg = src_name.rsplit(' ', 1)[-1][:-4] # final characters in src filename (after final space char)\n",
+    "\n",
+    "            if dst_final_seg.isdigit(): # Base case: original file ends in a digit\n",
+    "                dst_int = (int(dst_final_seg) + 1) if (row['add 1?'] == 1) else int(dst_final_seg) # add 1 (or don't)\n",
+    "                dst_name = src_name[:src_name.rfind(' ')] + ' ' + f'{dst_int:03d}' + '.mid'\n",
+    "            else:\n",
+    "                dst_name = src_name[:len(src_name)-4] + ' 001.mid' # Edge case: original file does not end in digit\n",
     "            \n",
     "            # Shortens name of copied file to everything after final '-' hyphen character\n",
     "            dst_name = dst_name.rsplit('- ')[-1]\n",
@@ -96,7 +97,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes:
- Enforced three-digit padding on integer suffixes to match Matthew's approach (Example: 00X instead of X)
- Refactored and added INPUTS section to allow user to specify:

1. Path where their input MIDI files are stored
2. Path where they want their renumbered MIDI files to go
3. Path to the Excel file specifying which of their pieces needs 1 added to the integer suffix on its filenames.